### PR TITLE
Fix docker run with "CMD" parameter

### DIFF
--- a/ubuntu/bionic/base/entrypoint.sh
+++ b/ubuntu/bionic/base/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-exec "$@"
+
+if [ $# -gt 1 ]; then
+    echo $@ | /bin/bash -li
+else
+    exec bash -li -c "$@"
+fi

--- a/ubuntu/bionic/core/entrypoint.sh
+++ b/ubuntu/bionic/core/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-exec "$@"
+
+if [ $# -gt 1 ]; then
+    echo $@ | /bin/bash -li
+else
+    exec bash -li -c "$@"
+fi

--- a/ubuntu/bionic/devel/entrypoint.sh
+++ b/ubuntu/bionic/devel/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-exec "$@"
+
+if [ $# -gt 1 ]; then
+    echo $@ | /bin/bash -li
+else
+    exec bash -li -c "$@"
+fi

--- a/ubuntu/xenial/base/entrypoint.sh
+++ b/ubuntu/xenial/base/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-exec "$@"
+
+if [ $# -gt 1 ]; then
+    echo $@ | /bin/bash -li
+else
+    exec bash -li -c "$@"
+fi

--- a/ubuntu/xenial/core/entrypoint.sh
+++ b/ubuntu/xenial/core/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-exec "$@"
+
+if [ $# -gt 1 ]; then
+    echo $@ | /bin/bash -li
+else
+    exec bash -li -c "$@"
+fi

--- a/ubuntu/xenial/devel/entrypoint.sh
+++ b/ubuntu/xenial/devel/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
-exec "$@"
+
+if [ $# -gt 1 ]; then
+    echo $@ | /bin/bash -li
+else
+    exec bash -li -c "$@"
+fi


### PR DESCRIPTION
This PR fixes #6.

Tested on my Ubuntu laptop.

```
$ docker run --rm -it -v "$(pwd):/home/ubuntu/test" tiryoh/ubuntu:bionic-dev ls -la test
ubuntu@e8a258b28b55:~
$ ls -la test
total 32
drwxrwxr-x 4 ubuntu   1004 4096 Feb  4 06:30 .
drwxr-xr-x 1 ubuntu ubuntu 4096 Feb  4 06:41 ..
-rw------- 1 ubuntu ubuntu  496 Feb  4 06:08 .bash_history
drwxrwxr-x 2 ubuntu   1004 4096 Feb  4 05:56 .circleci
drwxrwxr-x 8 ubuntu   1004 4096 Feb  4 05:56 .git
-rw-rw-r-- 1 ubuntu   1004   93 Feb  4 05:56 step1.sh
-rw-rw-r-- 1 ubuntu   1004 2335 Feb  4 05:56 step2.sh
ubuntu@e8a258b28b55:~
$ logout
```

```
$ docker run --rm -it -v "$(pwd):/home/ubuntu/test" tiryoh/ubuntu:bionic-dev "ls -la test"
total 32
drwxrwxr-x 4 ubuntu   1004 4096 Feb  4 06:30 .
drwxr-xr-x 1 ubuntu ubuntu 4096 Feb  4 06:40 ..
-rw------- 1 ubuntu ubuntu  496 Feb  4 06:08 .bash_history
drwxrwxr-x 2 ubuntu   1004 4096 Feb  4 05:56 .circleci
drwxrwxr-x 8 ubuntu   1004 4096 Feb  4 05:56 .git
-rw-rw-r-- 1 ubuntu   1004   93 Feb  4 05:56 step1.sh
-rw-rw-r-- 1 ubuntu   1004 2335 Feb  4 05:56 step2.sh
```

```
$ docker run --rm -it -v "$(pwd):/home/ubuntu/test" tiryoh/ubuntu:bionic-dev ls -la test/step*.sh
ubuntu@9ec54c425f7c:~
$ ls -la test/step1.sh test/step2.sh
-rw-rw-r-- 1 ubuntu 1004   93 Feb  4 05:56 test/step1.sh
-rw-rw-r-- 1 ubuntu 1004 2335 Feb  4 05:56 test/step2.sh
ubuntu@9ec54c425f7c:~
$ logout
```

```sh
$ docker run --rm -it -v "$(pwd):/home/ubuntu/test" tiryoh/ubuntu:bionic-dev "ls -la test/step*.sh"
-rw-rw-r-- 1 ubuntu 1004   93 Feb  4 05:56 test/step1.sh
-rw-rw-r-- 1 ubuntu 1004 2335 Feb  4 05:56 test/step2.sh
```